### PR TITLE
feat: 다이어리 기능 추가(이미지 업로드)

### DIFF
--- a/src/main/java/com/thinktrip/thinktrip_api/controller/DiaryController.java
+++ b/src/main/java/com/thinktrip/thinktrip_api/controller/DiaryController.java
@@ -6,7 +6,9 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.web.bind.annotation.*;
+import org.springframework.web.multipart.MultipartFile;
 
+import java.util.List;
 import java.util.Map;
 
 @RestController
@@ -16,19 +18,22 @@ public class DiaryController {
 
     private final DiaryService diaryService;
 
-    @PostMapping
+    @PostMapping(consumes = {"multipart/form-data"})
     public ResponseEntity<?> create(@PathVariable Long planId,
-                                    @RequestBody DiaryRequest request) {
+                                    @ModelAttribute("request") DiaryRequest request,
+                                    @RequestPart(value = "images", required = false) List<MultipartFile> images) {
         String email = getEmailFromToken();
-        diaryService.createDiary(planId, request, email);
+        diaryService.createDiary(planId, request, email, images);
         return ResponseEntity.ok(Map.of("message", "다이어리 저장 완료"));
     }
 
-    @PutMapping("/{diaryId}")
+    @PutMapping(value = "/{diaryId}", consumes = {"multipart/form-data"})
     public ResponseEntity<?> update(@PathVariable Long planId,
                                     @PathVariable Long diaryId,
-                                    @RequestBody DiaryRequest request) {
-        String email = getEmailFromToken();
+                                    @RequestPart("request") DiaryRequest request,
+                                    @RequestPart(value = "images", required = false) List<MultipartFile> images) {
+
+    String email = getEmailFromToken();
         diaryService.updateDiary(diaryId, request, email);
         return ResponseEntity.ok(Map.of("message", "다이어리 수정 완료"));
     }

--- a/src/main/java/com/thinktrip/thinktrip_api/domain/diary/Diary.java
+++ b/src/main/java/com/thinktrip/thinktrip_api/domain/diary/Diary.java
@@ -10,6 +10,8 @@ import org.hibernate.annotations.UpdateTimestamp;
 
 import java.time.LocalDate;
 import java.time.LocalDateTime;
+import java.util.ArrayList;
+import java.util.List;
 
 @Getter
 @Setter
@@ -38,4 +40,8 @@ public class Diary {
 
     @UpdateTimestamp
     private LocalDateTime updatedAt;
+
+    @OneToMany(mappedBy = "diary", cascade = CascadeType.ALL, orphanRemoval = true)
+    private List<DiaryImage> images = new ArrayList<>();
+
 }

--- a/src/main/java/com/thinktrip/thinktrip_api/domain/diary/DiaryImage.java
+++ b/src/main/java/com/thinktrip/thinktrip_api/domain/diary/DiaryImage.java
@@ -1,0 +1,25 @@
+// DiaryImage.java
+package com.thinktrip.thinktrip_api.domain.diary;
+
+import jakarta.persistence.*;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+@Getter
+@Setter
+@NoArgsConstructor
+@Entity
+@Table(name = "diary_images")
+public class DiaryImage {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    private String imageUrl;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "diary_id")
+    private Diary diary;
+}

--- a/src/main/java/com/thinktrip/thinktrip_api/domain/diary/DiaryImageRepository.java
+++ b/src/main/java/com/thinktrip/thinktrip_api/domain/diary/DiaryImageRepository.java
@@ -1,0 +1,6 @@
+package com.thinktrip.thinktrip_api.domain.diary;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface DiaryImageRepository extends JpaRepository<DiaryImage, Long> {
+}

--- a/src/main/java/com/thinktrip/thinktrip_api/dto/diary/DiaryResponse.java
+++ b/src/main/java/com/thinktrip/thinktrip_api/dto/diary/DiaryResponse.java
@@ -5,9 +5,10 @@ import lombok.Getter;
 
 import java.time.LocalDate;
 import java.time.LocalDateTime;
+import java.util.List;
 
-@Getter
 @Builder
+@Getter
 public class DiaryResponse {
     private Long id;
     private LocalDate startDate;
@@ -15,6 +16,7 @@ public class DiaryResponse {
     private String title;
     private String content;
     private Long travelPlanId;
+    private List<String> imageUrls;
     private LocalDateTime createdAt;
     private LocalDateTime updatedAt;
 }

--- a/src/main/java/com/thinktrip/thinktrip_api/service/diary/DiaryService.java
+++ b/src/main/java/com/thinktrip/thinktrip_api/service/diary/DiaryService.java
@@ -1,6 +1,7 @@
 package com.thinktrip.thinktrip_api.service.diary;
 
 import com.thinktrip.thinktrip_api.domain.diary.Diary;
+import com.thinktrip.thinktrip_api.domain.diary.DiaryImage;
 import com.thinktrip.thinktrip_api.domain.diary.DiaryRepository;
 import com.thinktrip.thinktrip_api.domain.travel.TravelPlan;
 import com.thinktrip.thinktrip_api.domain.travel.TravelPlanRepository;
@@ -9,7 +10,13 @@ import com.thinktrip.thinktrip_api.dto.diary.DiaryResponse;
 import com.thinktrip.thinktrip_api.domain.user.UserRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
+import org.springframework.web.multipart.MultipartFile;
 
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.util.UUID;
 import java.util.List;
 
 @Service
@@ -20,18 +27,41 @@ public class DiaryService {
     private final TravelPlanRepository travelPlanRepository;
     private final UserRepository userRepository;
 
-    public void createDiary(Long travelPlanId, DiaryRequest request, String email) {
+    public void createDiary(Long travelPlanId, DiaryRequest request, String email, List<MultipartFile> images) {
         TravelPlan plan = getOwnedPlan(travelPlanId, email);
 
         Diary diary = new Diary();
         diary.setDate(request.getStartDate());
-        diary.setDate(request.getEndDate());
         diary.setTitle(request.getTitle());
         diary.setContent(request.getContent());
         diary.setTravelPlan(plan);
 
+        if (images != null && !images.isEmpty()) {
+            for (MultipartFile image : images) {
+                String url = saveImage(image); // 이미지 저장 후 URL 리턴
+                DiaryImage diaryImage = new DiaryImage();
+                diaryImage.setImageUrl(url);
+                diaryImage.setDiary(diary);
+                diary.getImages().add(diaryImage);
+            }
+        }
+
         diaryRepository.save(diary);
     }
+
+    // 이미지 저장 메서드 예시
+    private String saveImage(MultipartFile image) {
+        try {
+            String filename = UUID.randomUUID() + "_" + image.getOriginalFilename();
+            Path savePath = Paths.get("uploads/diary", filename);
+            Files.createDirectories(savePath.getParent());
+            Files.write(savePath, image.getBytes());
+            return "/uploads/diary/" + filename;
+        } catch (IOException e) {
+            throw new RuntimeException("이미지 저장 실패", e);
+        }
+    }
+
 
     public void updateDiary(Long diaryId, DiaryRequest request, String email) {
         Diary diary = getOwnedDiary(diaryId, email);
@@ -79,6 +109,10 @@ public class DiaryService {
     }
 
     private DiaryResponse toDto(Diary diary) {
+        List<String> imageUrls = diary.getImages().stream()
+                .map(DiaryImage::getImageUrl)
+                .toList();
+
         return DiaryResponse.builder()
                 .id(diary.getId())
                 .startDate(diary.getTravelPlan().getStartDate())
@@ -86,6 +120,7 @@ public class DiaryService {
                 .title(diary.getTitle())
                 .content(diary.getContent())
                 .travelPlanId(diary.getTravelPlan().getId())
+                .imageUrls(imageUrls)
                 .createdAt(diary.getCreatedAt())
                 .updatedAt(diary.getUpdatedAt())
                 .build();


### PR DESCRIPTION
# 다이어리 기능 중 이미지 업로드 기능 추가

## 🚧 참고사항
- 기존 포스트맨에서 사용했던 raw 방식이 아닌, form-data 방식을 활용해야 합니다.
- 시작날짜, 종료날짜, 제목, 내용을 각각 작성해줘야 하며, 다중 파일 업로드가 가능합니다.

## ✅ 참고자료
<img src = "https://github.com/user-attachments/assets/415510e4-8b0a-4df0-a3a4-5794834757e9" width=450>
